### PR TITLE
Add options for dynmap customization

### DIFF
--- a/bukkit/src/main/java/com/griefdefender/hooks/config/category/DynmapCategory.java
+++ b/bukkit/src/main/java/com/griefdefender/hooks/config/category/DynmapCategory.java
@@ -85,6 +85,12 @@ public class DynmapCategory {
             + "Resident Trust: <span style=\"font-weight:bold;\">%residents%</span></div>"
             + "Access Trust: <span style=\"font-weight:bold;\">%accessors%</span></div>";
 
+    @Setting("marker-set-label")
+    public String markerSetLabel = "GriefDefender";
+
+    @Setting("missing-name-placeholder")
+    public String missingNamePlaceholder = "none";
+
     public DynmapCategory() {
         for (ClaimType type : GriefDefender.getRegistry().getAllOf(ClaimType.class)) {
             if (type == ClaimTypes.WILDERNESS) {

--- a/bukkit/src/main/java/com/griefdefender/hooks/provider/DynmapProvider.java
+++ b/bukkit/src/main/java/com/griefdefender/hooks/provider/DynmapProvider.java
@@ -63,7 +63,6 @@ import java.util.logging.Logger;
 
 public class DynmapProvider {
 
-    private static final String MOD_ID = "GriefDefender";
     private final Logger logger;
     private DynmapCommonAPI dynmap;
     private MarkerAPI markerapi;
@@ -100,10 +99,16 @@ public class DynmapProvider {
         info = info.replace("%claimname%",
                 claim.getData().getDisplayNameComponent().isPresent()
                         ? PlainComponentSerializer.plain().serialize(claim.getDisplayNameComponent().get())
-                        : "none");
+                        : cfg.missingNamePlaceholder);
         final Date lastActive = Date.from(claim.getData().getDateLastActive());
         info = info.replace("%lastseen%", lastActive.toString());
         info = info.replace("%gdtype%", claim.getType().toString());
+
+        info = info.replace("%width%", Integer.toString(claim.getWidth()));
+        info = info.replace("%length%", Integer.toString(claim.getLength()));
+        info = info.replace("%height%", Integer.toString(claim.getHeight()));
+        info = info.replace("%area%", Integer.toString(claim.getArea()));
+        info = info.replace("%volume%", Integer.toString(claim.getVolume()));
 
         final List<UUID> builderList = new ArrayList<>(claim.getUserTrusts(TrustTypes.BUILDER));
         final List<UUID> containerList = new ArrayList<>(claim.getUserTrusts(TrustTypes.CONTAINER));
@@ -352,9 +357,9 @@ public class DynmapProvider {
 
         this.set = this.markerapi.getMarkerSet("griefdefender.markerset");
         if (this.set == null) {
-            this.set = this.markerapi.createMarkerSet("griefdefender.markerset", MOD_ID, null, false);
+            this.set = this.markerapi.createMarkerSet("griefdefender.markerset", cfg.markerSetLabel, null, false);
         } else {
-            this.set.setMarkerSetLabel(MOD_ID);
+            this.set.setMarkerSetLabel(cfg.markerSetLabel);
         }
         if (this.set == null) {
             this.logger.severe("Error creating marker set");

--- a/bukkit/src/main/java/com/griefdefender/hooks/provider/DynmapProvider.java
+++ b/bukkit/src/main/java/com/griefdefender/hooks/provider/DynmapProvider.java
@@ -87,15 +87,10 @@ public class DynmapProvider {
     private Map<String, AreaMarker> areaMarkers = new ConcurrentHashMap<>();
 
     private String getWindowInfo(Claim claim, AreaMarker marker) {
-        String info;
-        if (claim.isAdminClaim()) {
-            info = "<div class=\"regioninfo\">" + this.cfg.infoWindowAdmin + "</div>";
-        } else {
-            info = "<div class=\"regioninfo\">" + this.cfg.infoWindowBasic + "</div>";
-        }
+        String info = claim.isAdminClaim() ? this.cfg.infoWindowAdmin : this.cfg.infoWindowBasic;
+
         info = info.replace("%owner%", claim.getOwnerName());
         info = info.replace("%owneruuid%", claim.getOwnerUniqueId().toString());
-        info = info.replace("%area%", Integer.toString(claim.getArea()));
         info = info.replace("%claimname%",
                 claim.getData().getDisplayNameComponent().isPresent()
                         ? PlainComponentSerializer.plain().serialize(claim.getDisplayNameComponent().get())
@@ -191,7 +186,7 @@ public class DynmapProvider {
         }
         info = info.replace("%managers%", trusted);
 
-        return info;
+        return "<div class=\"regioninfo\">" + info + "</div>";
     }
 
     private boolean isVisible(Claim claim, String owner, String worldname) {


### PR DESCRIPTION
This PR contains a commit which adds the following options for the dynmap integration:
* marker-set-label
* missing-name-placeholder

The `marker-set-label` is the string which is used in the dynmap layer list to identity the layer itself. In addition to that, currently the placeholder string, when a claim doesn't have a display name, is hardcoded to "none". To change this, the option `missing-name-placeholder` can be used.

In addition to that, it adds the following placeholders to the dynmap popup window:
- `%width%`
- `%length%`
- `%height%`
- `%area%`
- `%volume%`

It also removes the MOD_ID constant inside the DynmapProvider, as it isn't used anymore.

Furthermore it refactors the DynmapProvider by reducing duplicate code inside the class and also by making the code itself more readable.

_Please note: I do not have access to all the plugins that are referenced in this plugin. Therefore I cannot compile or test anything myself. Please point it out to me when something is broken or if I've missed something._